### PR TITLE
Avoid illegal invocation on Android

### DIFF
--- a/app/widgets/be.k0suke.fontawesome/controllers/widget.js
+++ b/app/widgets/be.k0suke.fontawesome/controllers/widget.js
@@ -38,5 +38,7 @@ exports.getProperties = function(option){
 	'show',
 	'toImage'
 ].forEach(function(func){
-	exports[func] = $.Widget[func];
+	exports[func] = function () {
+		$.Widget[func].apply($.Widget, arguments);
+	};
 });

--- a/app/widgets/be.k0suke.forecast/controllers/widget.js
+++ b/app/widgets/be.k0suke.forecast/controllers/widget.js
@@ -39,5 +39,7 @@ exports.getProperties = function(option){
 	'show',
 	'toImage'
 ].forEach(function(func){
-	exports[func] = $.Widget[func];
+	exports[func] = function () {
+		$.Widget[func].apply($.Widget, arguments);
+	};
 });

--- a/app/widgets/be.k0suke.ligaturesymbols/controllers/widget.js
+++ b/app/widgets/be.k0suke.ligaturesymbols/controllers/widget.js
@@ -38,5 +38,7 @@ exports.getProperties = function(option){
 	'show',
 	'toImage'
 ].forEach(function(func){
-	exports[func] = $.Widget[func];
+	exports[func] = function () {
+		$.Widget[func].apply($.Widget, arguments);
+	};
 });

--- a/app/widgets/be.k0suke.sspika/controllers/widget.js
+++ b/app/widgets/be.k0suke.sspika/controllers/widget.js
@@ -39,5 +39,7 @@ exports.getProperties = function(option){
 	'show',
 	'toImage'
 ].forEach(function(func){
-	exports[func] = $.Widget[func];
+	exports[func] = function () {
+		$.Widget[func].apply($.Widget, arguments);
+	};
 });

--- a/app/widgets/be.k0suke.sssocial/controllers/widget.js
+++ b/app/widgets/be.k0suke.sssocial/controllers/widget.js
@@ -39,5 +39,7 @@ exports.getProperties = function(option){
 	'show',
 	'toImage'
 ].forEach(function(func){
-	exports[func] = $.Widget[func];
+	exports[func] = function () {
+		$.Widget[func].apply($.Widget, arguments);
+	};
 });


### PR DESCRIPTION
Hi @k0sukey 

Thanks for nice library!

This widget exports the `Label`'s methods directly as the widget's methods. This works fine on iOS but it doesn't work on Android. (causing `TypeError: Illegal invocation`)

https://jira.appcelerator.org/browse/TIMOB-16795
https://jira.appcelerator.org/browse/TIMOB-16351
According to these tickets, it seems that copying methods of Ti.UI.Views to variables doesn't work on Android. (This could be a bug of titanium but it still exists anyway.)

This change fixes the above issue.

Thanks,
